### PR TITLE
Feature watchOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
     name: "Networking",
     platforms: [
         .iOS(SupportedPlatform.IOSVersion.v13),
-        .macOS(SupportedPlatform.MacOSVersion.v11)
+        .macOS(SupportedPlatform.MacOSVersion.v11),
+        .watchOS(SupportedPlatform.WatchOSVersion.v6)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/Networking/Core/SampleDataNetworking.swift
+++ b/Sources/Networking/Core/SampleDataNetworking.swift
@@ -10,10 +10,10 @@ import Combine
 import Foundation
 
 // For NSDataAsset import
-#if os(iOS)
-    import UIKit
-#else
+#if os(macOS)
     import AppKit
+#else
+    import UIKit
 #endif
 
 // Implementation of networking which reads data from files

--- a/Sources/Networking/Modifiers/Interceptors/LoggingInterceptor.swift
+++ b/Sources/Networking/Modifiers/Interceptors/LoggingInterceptor.swift
@@ -8,7 +8,11 @@
 
 import Combine
 import Foundation
+#if os(watchOS)
+import os
+#else
 import OSLog
+#endif
 
 // MARK: - Pretty logging modifier
 

--- a/Sources/Networking/Modifiers/Processors/EndpointRequestStorageProcessor.swift
+++ b/Sources/Networking/Modifiers/Processors/EndpointRequestStorageProcessor.swift
@@ -8,7 +8,12 @@
 
 import Combine
 import Foundation
+
+#if os(watchOS)
+import os
+#else
 import OSLog
+#endif
 
 // MARK: - Defines data model storing full endpoint request
 

--- a/Sources/Networking/Reachability/Reachability.swift
+++ b/Sources/Networking/Reachability/Reachability.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 STRV. All rights reserved.
 //
 
+#if !os(watchOS)
 import Combine
 import Foundation
 import SystemConfiguration
@@ -247,3 +248,4 @@ private class ReachabilityWeakifier {
         self.reachability = reachability
     }
 }
+#endif

--- a/Sources/Networking/Reachability/SCNetworkReachabilityFlags+Reachability.swift
+++ b/Sources/Networking/Reachability/SCNetworkReachabilityFlags+Reachability.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 STRV. All rights reserved.
 //
 
+#if !os(watchOS)
 import Foundation
 import SystemConfiguration
 
@@ -103,3 +104,4 @@ extension SCNetworkReachabilityFlags {
         return "\(wwan)\(reachable) \(connectionRequired)\(transientConnection)\(interventionRequired)\(connectionOnTraffic)\(connectionOnDemand)\(localAddress)\(direct)"
     }
 }
+#endif

--- a/ios-networking.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios-networking.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
I am using this version of Networking in SwiftUI iWeather watchOS app. I basically left out the whole Reachability functionality. Not sure if it's ok or if it could be done differently.