### PR TITLE
fix: EndpointRequest's initializer method made public

### DIFF
--- a/Sources/Networking/Core/EndpointRequest.swift
+++ b/Sources/Networking/Core/EndpointRequest.swift
@@ -16,7 +16,7 @@ public struct EndpointRequest: Identifiable {
     public let sessionId: String
     public let endpoint: Requestable
 
-    init(_ endpoint: Requestable, sessionId: String) {
+    public init(_ endpoint: Requestable, sessionId: String) {
         id = "\(endpoint.identifier)_\(Date().timeIntervalSince1970)"
         self.endpoint = endpoint
         self.sessionId = sessionId


### PR DESCRIPTION
During the integration of Networking package into iWeather, I bumped into a problem where I could not finish tests for a user created adapter because I was not able to initialise a mock EndpointRequest object due to its initialiser being internal.