### PR TITLE
Data and file upload support

### DIFF
--- a/NetworkingSampleApp/NetworkingSampleApp.xcodeproj/project.pbxproj
+++ b/NetworkingSampleApp/NetworkingSampleApp.xcodeproj/project.pbxproj
@@ -27,6 +27,13 @@
 		58E4E0F129850E86000ACBC0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E4E0F029850E86000ACBC0 /* ContentView.swift */; };
 		58FB80C7298521FF0031FC59 /* AuthorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FB80C6298521FF0031FC59 /* AuthorizationView.swift */; };
 		58FB80CE29895ABF0031FC59 /* TestData.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 58FB80CD29895ABF0031FC59 /* TestData.xcassets */; };
+		B52674BA2A370C15006D3B9C /* SampleUploadRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52674B92A370C15006D3B9C /* SampleUploadRouter.swift */; };
+		B52674BD2A370D1D006D3B9C /* UploadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52674BC2A370D1D006D3B9C /* UploadService.swift */; };
+		B52674BF2A370D33006D3B9C /* UploadItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52674BE2A370D33006D3B9C /* UploadItem.swift */; };
+		B52674C12A370DFF006D3B9C /* UploadsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52674C02A370DFF006D3B9C /* UploadsViewModel.swift */; };
+		B52674C32A370E35006D3B9C /* UploadItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52674C22A370E35006D3B9C /* UploadItemViewModel.swift */; };
+		B52674C52A37102D006D3B9C /* UploadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52674C42A37102D006D3B9C /* UploadsView.swift */; };
+		B52674C72A371046006D3B9C /* UploadItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52674C62A371046006D3B9C /* UploadItemView.swift */; };
 		DD410D6F293F2E6E006D8E31 /* AuthorizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD410D6E293F2E6E006D8E31 /* AuthorizationViewModel.swift */; };
 		DD6E48732A0E24D30025AD05 /* DownloadProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6E48722A0E24D30025AD05 /* DownloadProgressView.swift */; };
 		DD6E48762A0E2CD30025AD05 /* DownloadAPIManager+SharedInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6E48752A0E2CD30025AD05 /* DownloadAPIManager+SharedInstance.swift */; };
@@ -60,6 +67,13 @@
 		58E4E0F029850E86000ACBC0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		58FB80C6298521FF0031FC59 /* AuthorizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationView.swift; sourceTree = "<group>"; };
 		58FB80CD29895ABF0031FC59 /* TestData.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = TestData.xcassets; sourceTree = "<group>"; };
+		B52674B92A370C15006D3B9C /* SampleUploadRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleUploadRouter.swift; sourceTree = "<group>"; };
+		B52674BC2A370D1D006D3B9C /* UploadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadService.swift; sourceTree = "<group>"; };
+		B52674BE2A370D33006D3B9C /* UploadItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadItem.swift; sourceTree = "<group>"; };
+		B52674C02A370DFF006D3B9C /* UploadsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadsViewModel.swift; sourceTree = "<group>"; };
+		B52674C22A370E35006D3B9C /* UploadItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadItemViewModel.swift; sourceTree = "<group>"; };
+		B52674C42A37102D006D3B9C /* UploadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadsView.swift; sourceTree = "<group>"; };
+		B52674C62A371046006D3B9C /* UploadItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadItemView.swift; sourceTree = "<group>"; };
 		DD410D6E293F2E6E006D8E31 /* AuthorizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationViewModel.swift; sourceTree = "<group>"; };
 		DD6E48722A0E24D30025AD05 /* DownloadProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadProgressView.swift; sourceTree = "<group>"; };
 		DD6E48752A0E2CD30025AD05 /* DownloadAPIManager+SharedInstance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DownloadAPIManager+SharedInstance.swift"; sourceTree = "<group>"; };
@@ -126,8 +140,9 @@
 		23A575ED25F8BF0E00617551 /* Scenes */ = {
 			isa = PBXGroup;
 			children = (
-				58C3E75B29B78ED3004FD1CD /* Download */,
 				58FB80C5298521DA0031FC59 /* Authorization */,
+				58C3E75B29B78ED3004FD1CD /* Download */,
+				B52674BB2A370D0D006D3B9C /* Upload */,
 			);
 			path = Scenes;
 			sourceTree = "<group>";
@@ -168,6 +183,7 @@
 			children = (
 				DDD3AD1E2950E794006CB777 /* SampleAuthRouter.swift */,
 				58C3E76029B79259004FD1CD /* SampleDownloadRouter.swift */,
+				B52674B92A370C15006D3B9C /* SampleUploadRouter.swift */,
 				23EA9CE9292FB70A00B8E418 /* SampleUserRouter.swift */,
 			);
 			path = Routers;
@@ -219,6 +235,19 @@
 				58FB80CD29895ABF0031FC59 /* TestData.xcassets */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		B52674BB2A370D0D006D3B9C /* Upload */ = {
+			isa = PBXGroup;
+			children = (
+				B52674BE2A370D33006D3B9C /* UploadItem.swift */,
+				B52674C62A371046006D3B9C /* UploadItemView.swift */,
+				B52674C22A370E35006D3B9C /* UploadItemViewModel.swift */,
+				B52674BC2A370D1D006D3B9C /* UploadService.swift */,
+				B52674C42A37102D006D3B9C /* UploadsView.swift */,
+				B52674C02A370DFF006D3B9C /* UploadsViewModel.swift */,
+			);
+			path = Upload;
 			sourceTree = "<group>";
 		};
 		DD6E48742A0E2CC70025AD05 /* Extensions */ = {
@@ -312,6 +341,7 @@
 				58E4E0ED2982D884000ACBC0 /* SampleAuthorizationStorageManager.swift in Sources */,
 				23EA9CF6292FB70A00B8E418 /* SampleAPIError.swift in Sources */,
 				58E4E0F129850E86000ACBC0 /* ContentView.swift in Sources */,
+				B52674BD2A370D1D006D3B9C /* UploadService.swift in Sources */,
 				58C3E76529B7D709004FD1CD /* DownloadProgressViewModel.swift in Sources */,
 				23EA9CF9292FB70A00B8E418 /* SampleUserResponse.swift in Sources */,
 				DDD3AD1F2950E794006CB777 /* SampleAuthRouter.swift in Sources */,
@@ -320,11 +350,17 @@
 				23EA9CFA292FB70A00B8E418 /* SampleUserAuthRequest.swift in Sources */,
 				58C3E76129B79259004FD1CD /* SampleDownloadRouter.swift in Sources */,
 				23EA9CF4292FB70A00B8E418 /* SampleUserRouter.swift in Sources */,
+				B52674BF2A370D33006D3B9C /* UploadItem.swift in Sources */,
 				23EA9CF5292FB70A00B8E418 /* SampleAPIConstants.swift in Sources */,
 				58FB80C7298521FF0031FC59 /* AuthorizationView.swift in Sources */,
 				DD410D6F293F2E6E006D8E31 /* AuthorizationViewModel.swift in Sources */,
+				B52674BA2A370C15006D3B9C /* SampleUploadRouter.swift in Sources */,
+				B52674C72A371046006D3B9C /* UploadItemView.swift in Sources */,
 				58C3E75F29B78EE8004FD1CD /* DownloadsViewModel.swift in Sources */,
 				58C3E75E29B78EE6004FD1CD /* DownloadsView.swift in Sources */,
+				B52674C32A370E35006D3B9C /* UploadItemViewModel.swift in Sources */,
+				B52674C12A370DFF006D3B9C /* UploadsViewModel.swift in Sources */,
+				B52674C52A37102D006D3B9C /* UploadsView.swift in Sources */,
 				DD6E48732A0E24D30025AD05 /* DownloadProgressView.swift in Sources */,
 				23EA9CF8292FB70A00B8E418 /* SampleUsersResponse.swift in Sources */,
 			);

--- a/NetworkingSampleApp/NetworkingSampleApp/API/Routers/SampleUploadRouter.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/API/Routers/SampleUploadRouter.swift
@@ -1,0 +1,42 @@
+//
+//  SampleUploadRouter.swift
+//  NetworkingSampleApp
+//
+//  Created by Tony Ngo on 12.06.2023.
+//
+
+import Foundation
+import Networking
+import UniformTypeIdentifiers
+
+enum SampleUploadRouter: Requestable {
+    case image
+    case file(URL)
+
+    var baseURL: URL {
+        fatalError("Provide your API base URL for upload")
+    }
+
+    var headers: [String : String]? {
+        switch self {
+        case .image:
+            return ["Content-Type": "image/png"]
+        case let .file(url):
+            return ["Content-Type": url.mimeType]
+        }
+    }
+
+    var path: String {
+        fatalError("Provide your API endpoint path for upload")
+    }
+
+    var method: HTTPMethod {
+        .post
+    }
+}
+
+private extension URL {
+    var mimeType: String {
+        UTType(filenameExtension: pathExtension)?.preferredMIMEType ?? "application/octet-stream"
+    }
+}

--- a/NetworkingSampleApp/NetworkingSampleApp/ContentView.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/ContentView.swift
@@ -5,11 +5,13 @@
 //  Created by Matej Molnár on 28.01.2023.
 //
 
+import Networking
 import SwiftUI
 
 enum NetworkingFeature: String, Hashable, CaseIterable {
     case authorization
     case downloads
+    case uploads
 }
 
 struct ContentView: View {
@@ -27,6 +29,12 @@ struct ContentView: View {
                     AuthorizationView()
                 case .downloads:
                     DownloadsView()
+                case .uploads:
+                    UploadsView(viewModel: UploadsViewModel(
+                        uploadService: UploadService(
+                            uploadManager: UploadAPIManager()
+                        )
+                    ))
                 }
             }
         }

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItem.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItem.swift
@@ -1,0 +1,13 @@
+//
+//  UploadItem.swift
+//  NetworkingSampleApp
+//
+//  Created by Tony Ngo on 12.06.2023.
+//
+
+import Foundation
+
+struct UploadItem: Hashable {
+    let id: String
+    let fileName: String
+}

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemView.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemView.swift
@@ -1,0 +1,76 @@
+//
+//  UploadItemView.swift
+//  NetworkingSampleApp
+//
+//  Created by Tony Ngo on 12.06.2023.
+//
+
+import SwiftUI
+
+struct UploadItemView: View {
+    @ObservedObject var viewModel: UploadItemViewModel
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                HStack {
+                    Text(viewModel.fileName)
+                        .font(.subheadline)
+                    Text(viewModel.isCancelled ? "Cancelled" : viewModel.formattedProgress)
+                        .font(.footnote)
+                        .foregroundColor(.gray)
+                }
+
+                Spacer()
+
+                if !viewModel.isCancelled && !viewModel.isRetryable {
+                    HStack {
+                        Button(action: {
+                            // TODO: allow pause/resume
+                        }, label: {
+                            Image(systemName: viewModel.isPaused ? "play" : "pause")
+                                .symbolVariant(.circle.fill)
+                                .font(.title2)
+                                .symbolRenderingMode(.hierarchical)
+                                .foregroundStyle(.blue)
+                        })
+                        .buttonStyle(.plain)
+                        .contentShape(Circle())
+
+                        Button(action: {
+                            // TODO: allow cancel
+                        }, label: {
+                            Image(systemName: "x")
+                                .symbolVariant(.circle.fill)
+                                .font(.title2)
+                                .symbolRenderingMode(.hierarchical)
+                                .foregroundStyle(.red)
+                        })
+                        .buttonStyle(.plain)
+                        .contentShape(Circle())
+                    }
+                } else if viewModel.isRetryable {
+                    Button(action: {
+                        // TODO: Allow retry
+                    }, label: {
+                        Image(systemName: "repeat")
+                            .symbolVariant(.circle.fill)
+                            .font(.title2)
+                            .symbolRenderingMode(.hierarchical)
+                            .foregroundStyle(.blue)
+                    })
+                    .buttonStyle(.plain)
+                    .contentShape(Circle())
+                }
+            }
+
+            if !viewModel.isCancelled {
+                ProgressView(value: viewModel.progress, total: viewModel.totalProgress)
+                    .progressViewStyle(.linear)
+            }
+        }
+        .animation(.easeOut(duration: 0.3), value: viewModel.progress)
+        .padding(.vertical, 8)
+        .task { await viewModel.observeProgress() }
+    }
+}

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemView.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemView.swift
@@ -25,42 +25,26 @@ struct UploadItemView: View {
 
                 if !viewModel.isCancelled && !viewModel.isRetryable {
                     HStack {
-                        Button(action: {
-                            viewModel.isPaused ? viewModel.resume() : viewModel.pause()
-                        }, label: {
-                            Image(systemName: viewModel.isPaused ? "play" : "pause")
-                                .symbolVariant(.circle.fill)
-                                .font(.title2)
-                                .symbolRenderingMode(.hierarchical)
-                                .foregroundStyle(.blue)
-                        })
-                        .buttonStyle(.plain)
-                        .contentShape(Circle())
+                        button(
+                            symbol: viewModel.isPaused ? "play" : "pause",
+                            color: .blue,
+                            action: { viewModel.isPaused ? viewModel.resume() : viewModel.pause() }
+                        )
 
-                        Button(action: {
-                            viewModel.cancel()
-                        }, label: {
-                            Image(systemName: "x")
-                                .symbolVariant(.circle.fill)
-                                .font(.title2)
-                                .symbolRenderingMode(.hierarchical)
-                                .foregroundStyle(.red)
-                        })
-                        .buttonStyle(.plain)
-                        .contentShape(Circle())
+                        button(
+                            symbol: "x",
+                            color: .red,
+                            action: { viewModel.cancel() }
+                        )
                     }
                 } else if viewModel.isRetryable {
-                    Button(action: {
-                        // TODO: Allow retry
-                    }, label: {
-                        Image(systemName: "repeat")
-                            .symbolVariant(.circle.fill)
-                            .font(.title2)
-                            .symbolRenderingMode(.hierarchical)
-                            .foregroundStyle(.blue)
-                    })
-                    .buttonStyle(.plain)
-                    .contentShape(Circle())
+                    button(
+                        symbol: "repeat",
+                        color: .blue,
+                        action: {
+                            // TODO: Allow retry
+                        }
+                    )
                 }
             }
 
@@ -72,5 +56,22 @@ struct UploadItemView: View {
         .animation(.easeOut(duration: 0.3), value: viewModel.progress)
         .padding(.vertical, 8)
         .task { await viewModel.observeProgress() }
+    }
+}
+
+private extension UploadItemView {
+    func button(symbol: String, color: Color, action: @escaping () -> Void) -> some View {
+        Button(
+            action: action,
+            label: {
+                Image(systemName: symbol)
+                    .symbolVariant(.circle.fill)
+                    .font(.title2)
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(color)
+            }
+        )
+        .buttonStyle(.plain)
+        .contentShape(Circle())
     }
 }

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemView.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemView.swift
@@ -16,14 +16,14 @@ struct UploadItemView: View {
                 HStack {
                     Text(viewModel.fileName)
                         .font(.subheadline)
-                    Text(viewModel.isCancelled ? "Cancelled" : viewModel.formattedProgress)
+                    Text(viewModel.stateTitle)
                         .font(.footnote)
                         .foregroundColor(.gray)
                 }
 
                 Spacer()
 
-                if !viewModel.isCancelled && !viewModel.isRetryable {
+                if !viewModel.isCancelled && !viewModel.isRetryable && !viewModel.isCompleted {
                     HStack {
                         button(
                             symbol: viewModel.isPaused ? "play" : "pause",

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemView.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemView.swift
@@ -26,7 +26,7 @@ struct UploadItemView: View {
                 if !viewModel.isCancelled && !viewModel.isRetryable {
                     HStack {
                         Button(action: {
-                            // TODO: allow pause/resume
+                            viewModel.isPaused ? viewModel.resume() : viewModel.pause()
                         }, label: {
                             Image(systemName: viewModel.isPaused ? "play" : "pause")
                                 .symbolVariant(.circle.fill)
@@ -38,7 +38,7 @@ struct UploadItemView: View {
                         .contentShape(Circle())
 
                         Button(action: {
-                            // TODO: allow cancel
+                            viewModel.cancel()
                         }, label: {
                             Image(systemName: "x")
                                 .symbolVariant(.circle.fill)

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemView.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemView.swift
@@ -41,14 +41,12 @@ struct UploadItemView: View {
                     button(
                         symbol: "repeat",
                         color: .blue,
-                        action: {
-                            // TODO: Allow retry
-                        }
+                        action: { viewModel.retry() }
                     )
                 }
             }
 
-            if !viewModel.isCancelled {
+            if !viewModel.isCancelled && !viewModel.isRetryable {
                 ProgressView(value: viewModel.progress, total: viewModel.totalProgress)
                     .progressViewStyle(.linear)
             }

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemViewModel.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemViewModel.swift
@@ -1,0 +1,42 @@
+//
+//  UploadItemViewModel.swift
+//  NetworkingSampleApp
+//
+//  Created by Tony Ngo on 12.06.2023.
+//
+
+import Foundation
+
+@MainActor
+final class UploadItemViewModel: ObservableObject {
+    @Published private(set) var progress: Double = 0
+    @Published private(set) var formattedProgress: String = ""
+    @Published private(set) var isPaused = false
+    @Published private(set) var isCancelled = false
+    @Published private(set) var isRetryable = false
+
+    let fileName: String
+    let totalProgress = 100.0
+
+    private let item: UploadItem
+    private let uploadService: UploadService
+
+    init(item: UploadItem, uploadService: UploadService) {
+        self.item = item
+        self.fileName = item.fileName
+        self.uploadService = uploadService
+    }
+}
+
+extension UploadItemViewModel {
+    func observeProgress() async {
+        let uploadStateStream = await uploadService.uploadStateStream(for: item.id)
+        for await state in uploadStateStream {
+            progress = state.fractionCompleted * 100
+            formattedProgress = String(format: "%.2f", progress) + "%"
+            isPaused = state.isSuspended
+            isCancelled = state.cancelled
+            isRetryable = state.cancelled || state.timedOut
+        }
+    }
+}

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemViewModel.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemViewModel.swift
@@ -15,6 +15,14 @@ final class UploadItemViewModel: ObservableObject {
     @Published private(set) var isCancelled = false
     @Published private(set) var isRetryable = false
 
+    var stateTitle: String {
+        isCancelled
+            ? "Cancelled"
+            : isCompleted ? "Completed" : formattedProgress
+    }
+
+    var isCompleted: Bool { progress == 100 }
+
     let fileName: String
     let totalProgress = 100.0
 

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemViewModel.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemViewModel.swift
@@ -36,7 +36,7 @@ extension UploadItemViewModel {
             formattedProgress = String(format: "%.2f", progress) + "%"
             isPaused = state.isSuspended
             isCancelled = state.cancelled
-            isRetryable = state.cancelled || state.timedOut
+            isRetryable = state.cancelled || state.timedOut || state.error != nil
         }
     }
 
@@ -61,6 +61,13 @@ extension UploadItemViewModel {
             await uploadService.cancel(taskId: item.id)
             isCancelled = true
             isRetryable = true
+        }
+    }
+
+    func retry() {
+        Task {
+            try await uploadService.retry(item)
+            await observeProgress()
         }
     }
 }

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemViewModel.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadItemViewModel.swift
@@ -39,4 +39,28 @@ extension UploadItemViewModel {
             isRetryable = state.cancelled || state.timedOut
         }
     }
+
+    func pause() {
+        Task {
+            await uploadService.pause(taskId: item.id)
+            isPaused = true
+            isRetryable = false
+        }
+    }
+
+    func resume() {
+        Task {
+            await uploadService.resume(taskId: item.id)
+            isPaused = false
+            isRetryable = false
+        }
+    }
+
+    func cancel() {
+        Task {
+            await uploadService.cancel(taskId: item.id)
+            isCancelled = true
+            isRetryable = true
+        }
+    }
 }

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadService.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadService.swift
@@ -24,7 +24,8 @@ extension UploadService {
     func uploadImage(_ data: Data, fileName: String) async throws -> UploadItem {
         let task = try await uploadManager.upload(
             data: data,
-            to: SampleUploadRouter.image
+            to: SampleUploadRouter.image,
+            retryConfiguration: .default
         )
         return UploadItem(
             id: task.id,
@@ -35,7 +36,8 @@ extension UploadService {
     func uploadFile(_ fileUrl: URL) async throws -> UploadItem {
         let task = try await uploadManager.upload(
             fromFile: fileUrl,
-            to: SampleUploadRouter.file(fileUrl)
+            to: SampleUploadRouter.file(fileUrl),
+            retryConfiguration: .default
         )
         return UploadItem(
             id: task.id,
@@ -57,6 +59,13 @@ extension UploadService {
 
     func cancel(taskId: String) async {
         await uploadManager.task(with: taskId)?.cancel()
+    }
+
+    func retry(_ uploadItem: UploadItem) async throws {
+        try await uploadManager.retry(
+            taskId: uploadItem.id,
+            retryConfiguration: .default
+        )
     }
 }
 

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadService.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadService.swift
@@ -46,6 +46,18 @@ extension UploadService {
     func uploadStateStream(for uploadTaskId: String) async -> UploadAPIManaging.StateStream {
         await uploadManager.stateStream(for: uploadTaskId)
     }
+
+    func pause(taskId: String) async {
+        await uploadManager.task(with: taskId)?.pause()
+    }
+
+    func resume(taskId: String) async {
+        await uploadManager.task(with: taskId)?.resume()
+    }
+
+    func cancel(taskId: String) async {
+        await uploadManager.task(with: taskId)?.cancel()
+    }
 }
 
 private extension UploadAPIManaging {

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadService.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadService.swift
@@ -1,0 +1,55 @@
+//
+//  UploadService.swift
+//  NetworkingSampleApp
+//
+//  Created by Tony Ngo on 12.06.2023.
+//
+
+import Foundation
+import Networking
+
+final class UploadService {
+    private let uploadManager: UploadAPIManaging
+
+    init(uploadManager: UploadAPIManaging) {
+        self.uploadManager = uploadManager
+    }
+
+    deinit {
+        uploadManager.invalidateSession(shouldFinishTasks: false)
+    }
+}
+
+extension UploadService {
+    func uploadImage(_ data: Data, fileName: String) async throws -> UploadItem {
+        let task = try await uploadManager.upload(
+            data: data,
+            to: SampleUploadRouter.image
+        )
+        return UploadItem(
+            id: task.id,
+            fileName: fileName
+        )
+    }
+
+    func uploadFile(_ fileUrl: URL) async throws -> UploadItem {
+        let task = try await uploadManager.upload(
+            fromFile: fileUrl,
+            to: SampleUploadRouter.file(fileUrl)
+        )
+        return UploadItem(
+            id: task.id,
+            fileName: fileUrl.lastPathComponent
+        )
+    }
+
+    func uploadStateStream(for uploadTaskId: String) async -> UploadAPIManaging.StateStream {
+        await uploadManager.stateStream(for: uploadTaskId)
+    }
+}
+
+private extension UploadAPIManaging {
+    func task(with id: String) async -> UploadTask? {
+        await allTasks.first { $0.id == id }
+    }
+}

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadsView.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadsView.swift
@@ -58,5 +58,6 @@ struct UploadsView: View {
                 }
             }
         }
+        .navigationTitle("Uploads")
     }
 }

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadsView.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadsView.swift
@@ -1,0 +1,62 @@
+//
+//  UploadsView.swift
+//  NetworkingSampleApp
+//
+//  Created by Tony Ngo on 12.06.2023.
+//
+
+import SwiftUI
+import PhotosUI
+
+struct UploadsView: View {
+    @ObservedObject var viewModel: UploadsViewModel
+    @State var isPhotosPickerPresented = false
+    @State var isFileImporterPresented = false
+    @State var selectedPhotoPickerItem: PhotosPickerItem?
+
+    var body: some View {
+        List {
+            Section("Upload") {
+                Button("Photo") { isPhotosPickerPresented = true }
+                    .photosPicker(
+                        isPresented: $isPhotosPickerPresented,
+                        selection: $selectedPhotoPickerItem,
+                        matching: .images
+                    )
+                    .onChange(of: selectedPhotoPickerItem) { photo in
+                        Task {
+                            if let data = try? await photo?.loadTransferable(type: Data.self) {
+                                await viewModel.uploadImage(
+                                    data,
+                                    fileName: selectedPhotoPickerItem?.supportedContentTypes.first?.preferredFilenameExtension
+                                )
+                            }
+                        }
+                    }
+
+                Button("File") { isFileImporterPresented = true }
+                    .fileImporter(
+                        isPresented: $isFileImporterPresented,
+                        allowedContentTypes: [.mp3, .mpeg4Movie]
+                    ) { result in
+                        Task {
+                            if let fileUrl = try? result.get() {
+                                await viewModel.uploadFile(at: fileUrl)
+                            }
+                        }
+                    }
+            }
+
+            if !viewModel.uploadItemViewModels.isEmpty {
+                Section("Upload progress") {
+                    VStack {
+                        ForEach(viewModel.uploadItemViewModels.indices, id: \.self) { index in
+                            let viewModel = viewModel.uploadItemViewModels[index]
+                            UploadItemView(viewModel: viewModel)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadsViewModel.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadsViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 @MainActor
 final class UploadsViewModel: ObservableObject {
     @Published var error: Error?
-    @Published var uploadItemViewModels: [UploadItemViewModel] = []
+    @Published private(set) var uploadItemViewModels: [UploadItemViewModel] = []
 
     private let uploadService: UploadService
 

--- a/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadsViewModel.swift
+++ b/NetworkingSampleApp/NetworkingSampleApp/Scenes/Upload/UploadsViewModel.swift
@@ -1,0 +1,45 @@
+//
+//  UploadsViewModel.swift
+//  NetworkingSampleApp
+//
+//  Created by Tony Ngo on 12.06.2023.
+//
+
+import Foundation
+
+@MainActor
+final class UploadsViewModel: ObservableObject {
+    @Published var error: Error?
+    @Published var uploadItemViewModels: [UploadItemViewModel] = []
+
+    private let uploadService: UploadService
+
+    init(uploadService: UploadService) {
+        self.uploadService = uploadService
+    }
+}
+
+extension UploadsViewModel {
+    func uploadImage(_ imageData: Data, fileName: String?) async {
+        do {
+            let uploadItem = try await uploadService.uploadImage(
+                imageData,
+                fileName: fileName ?? ""
+            )
+            uploadItemViewModels.append(UploadItemViewModel(item: uploadItem, uploadService: uploadService))
+        } catch {
+            print("Failed to upload with error", error)
+            self.error = error
+        }
+    }
+
+    func uploadFile(at fileUrl: URL) async {
+        do {
+            let uploadItem = try await uploadService.uploadFile(fileUrl)
+            uploadItemViewModels.append(UploadItemViewModel(item: uploadItem, uploadService: uploadService))
+        } catch {
+            print("Failed to upload with error", error)
+            self.error = error
+        }
+    }
+}

--- a/Sources/Networking/Core/Upload/UploadAPIManager.swift
+++ b/Sources/Networking/Core/Upload/UploadAPIManager.swift
@@ -224,15 +224,7 @@ private extension UploadAPIManager {
             task.resume()
             return uploadTask
         } catch {
-            do {
-                return try await uploadRequest(
-                    uploadable,
-                    request: request,
-                    retryConfiguration: retryConfiguration
-                )
-            } catch {
-                throw await errorProcessors.process(error, for: request)
-            }
+            throw await errorProcessors.process(error, for: request)
         }
     }
 
@@ -270,5 +262,3 @@ private extension UploadAPIManager {
             .first { $0.taskIdentifier == task.taskIdentifier }
     }
 }
-
-

--- a/Sources/Networking/Core/Upload/UploadAPIManager.swift
+++ b/Sources/Networking/Core/Upload/UploadAPIManager.swift
@@ -1,0 +1,152 @@
+//
+//  UploadAPIManager.swift
+//  
+//
+//  Created by Tony Ngo on 12.06.2023.
+//
+
+import Combine
+import Foundation
+
+/// Default upload API manager
+open class UploadAPIManager: NSObject {
+    public var allTasks: [UploadTask] {
+        get async {
+            let activeTasks = await urlSession.allTasks.compactMap { $0 as? URLSessionUploadTask }
+            return await uploadTasks
+                .getValues()
+                .values
+                // Values may contain inactive tasks
+                .filter { activeTasks.contains($0.task) }
+        }
+    }
+
+    private var uploadTasks = ThreadSafeDictionary<String, UploadTask>()
+
+    private lazy var urlSession = URLSession(
+        configuration: urlSessionConfiguration,
+        delegate: self,
+        delegateQueue: nil
+    )
+
+    private let requestAdapters: [RequestAdapting]
+    private let responseProcessors: [ResponseProcessing]
+    private let errorProcessors: [ErrorProcessing]
+    private let urlSessionConfiguration: URLSessionConfiguration
+    private let sessionId: String
+
+    public init(
+        urlSessionConfiguration: URLSessionConfiguration = .default,
+        requestAdapters: [RequestAdapting] = [],
+        responseProcessors: [ResponseProcessing] = [StatusCodeProcessor.shared],
+        errorProcessors: [ErrorProcessing] = []
+    ) {
+        self.urlSessionConfiguration = urlSessionConfiguration
+        self.requestAdapters = requestAdapters
+        self.responseProcessors = responseProcessors
+        self.errorProcessors = errorProcessors
+        self.sessionId = Date.now.ISO8601Format()
+        super.init()
+    }
+}
+
+// MARK: - URLSessionDelegate, URLSessionTaskDelegate
+extension UploadAPIManager: URLSessionDelegate, URLSessionTaskDelegate {}
+
+// MARK: - Public API
+extension UploadAPIManager: UploadAPIManaging {
+    public func invalidateSession(shouldFinishTasks: Bool) {
+        if shouldFinishTasks {
+            urlSession.finishTasksAndInvalidate()
+        } else {
+            urlSession.invalidateAndCancel()
+        }
+    }
+
+    public func upload(
+        data: Data,
+        to endpoint: Requestable
+    ) async throws -> UploadTask {
+        let endpointRequest = EndpointRequest(endpoint, sessionId: sessionId)
+        return try await uploadRequest(.data(data), request: endpointRequest)
+    }
+
+    public func upload(
+        fromFile fileUrl: URL,
+        to endpoint: Requestable
+    ) async throws -> UploadTask {
+        let endpointRequest = EndpointRequest(endpoint, sessionId: sessionId)
+        return try await uploadRequest(.file(fileUrl), request: endpointRequest)
+    }
+
+    public func stateStream(for uploadTaskId: UploadTask.ID) async -> StateStream {
+        // TODO: Provide stream
+        Empty().eraseToAnyPublisher().values
+    }
+}
+
+private extension UploadAPIManager {
+    enum Uploadable {
+        case data(Data)
+        case file(URL)
+    }
+
+    func uploadRequest(
+        _ uploadable: Uploadable,
+        request: EndpointRequest
+    ) async throws -> UploadTask {
+        do {
+            let urlRequest = try await prepare(request)
+
+            let task = upload(uploadable, for: urlRequest) { _, _, _ in
+                // TODO: Handle request completion
+            }
+
+            let uploadTask = UploadTask(
+                task: task,
+                endpointRequest: request,
+                statePublisher: .init(UploadTask.State(task: task))
+            )
+
+            // Store the task for future processing
+            await uploadTasks.set(value: uploadTask, for: request.id)
+            task.resume()
+            return uploadTask
+        } catch {
+            do {
+                return try await uploadRequest(uploadable, request: request)
+            } catch {
+                throw await errorProcessors.process(error, for: request)
+            }
+        }
+    }
+
+    func upload(
+        _ uploadable: Uploadable,
+        for request: URLRequest,
+        completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void
+    ) -> URLSessionUploadTask {
+        switch uploadable {
+        case let .data(data):
+            return urlSession.uploadTask(
+                with: request,
+                from: data,
+                completionHandler: completionHandler
+            )
+        case let .file(fileUrl):
+            return urlSession.uploadTask(
+                with: request,
+                fromFile: fileUrl,
+                completionHandler: completionHandler
+            )
+        }
+    }
+
+    func prepare(_ request: EndpointRequest) async throws -> URLRequest {
+        let originalRequest = try request.endpoint.asRequest()
+        let adaptedRequest = try await requestAdapters.adapt(originalRequest, for: request)
+        return adaptedRequest
+    }
+}
+
+

--- a/Sources/Networking/Core/Upload/UploadAPIManaging.swift
+++ b/Sources/Networking/Core/Upload/UploadAPIManaging.swift
@@ -18,23 +18,36 @@ public protocol UploadAPIManaging {
     /// - Parameters:
     ///   - data: The data to send to the server.
     ///   - endpoint: The API endpoint to where data will be sent.
+    ///   - retryConfiguration: An optional configuration for retry behavior.
     /// - Returns: An `UploadTask` that represents this request.
     func upload(
         data: Data,
-        to endpoint: Requestable
+        to endpoint: Requestable,
+        retryConfiguration: RetryConfiguration?
     ) async throws -> UploadTask
 
     /// Initiates a file upload request for the specified endpoint.
     /// - Parameters:
     ///   - fileUrl: The file's URL to send to the server.
     ///   - endpoint: The API endpoint to where data will be sent.
+    ///   - retryConfiguration: An optional configuration for retry behavior.
     /// - Returns: An `UploadTask` that represents this request.
     func upload(
         fromFile fileUrl: URL,
-        to endpoint: Requestable
+        to endpoint: Requestable,
+        retryConfiguration: RetryConfiguration?
     ) async throws -> UploadTask
 
+    /// Retries the upload task with the specified identifier.
+    /// - Parameters:
+    ///   - taskId: The upload task's identifier to retry.
+    ///   - retryConfiguration: An optional configuration for retry behavior.
+    func retry(taskId: String, retryConfiguration: RetryConfiguration?) async throws
+
     /// Provides a stream of upload task's states for the specified `UploadTask.ID`.
+    ///
+    /// The stream stops providing updates whenever the internal stream produces an error,
+    /// i.e., `UploadTask.State.error` is non-nil. In such case, you can call `retry(taskId:)` to re-activate the stream for the specified `uploadTaskId`.
     /// - Parameter uploadTaskId: The identifier of the task to observe.
     /// - Returns: An asynchronous stream of upload state.
     func stateStream(for uploadTaskId: UploadTask.ID) async -> StateStream

--- a/Sources/Networking/Core/Upload/UploadAPIManaging.swift
+++ b/Sources/Networking/Core/Upload/UploadAPIManaging.swift
@@ -1,0 +1,47 @@
+//
+//  UploadAPIManaging.swift
+//  
+//
+//  Created by Tony Ngo on 12.06.2023.
+//
+
+import Combine
+import Foundation
+
+public protocol UploadAPIManaging {
+    typealias StateStream = AsyncPublisher<AnyPublisher<UploadTask.State, Never>>
+
+    /// Currently ongoing upload tasks.
+    var allTasks: [UploadTask] { get async }
+
+    /// Initiates a data upload request for the specified endpoint.
+    /// - Parameters:
+    ///   - data: The data to send to the server.
+    ///   - endpoint: The API endpoint to where data will be sent.
+    /// - Returns: An `UploadTask` that represents this request.
+    func upload(
+        data: Data,
+        to endpoint: Requestable
+    ) async throws -> UploadTask
+
+    /// Initiates a file upload request for the specified endpoint.
+    /// - Parameters:
+    ///   - fileUrl: The file's URL to send to the server.
+    ///   - endpoint: The API endpoint to where data will be sent.
+    /// - Returns: An `UploadTask` that represents this request.
+    func upload(
+        fromFile fileUrl: URL,
+        to endpoint: Requestable
+    ) async throws -> UploadTask
+
+    /// Provides a stream of upload task's states for the specified `UploadTask.ID`.
+    /// - Parameter uploadTaskId: The identifier of the task to observe.
+    /// - Returns: An asynchronous stream of upload state.
+    func stateStream(for uploadTaskId: UploadTask.ID) async -> StateStream
+
+    /// Invalidates the session with the option to wait for all outstanding (active) tasks.
+    ///
+    /// The internal implementation uses Apple's delegate pattern which retains a strong reference to the delegate. You must call this method to allow the manager to be released from the memory, otherwise your app will be leaking until your app exits or the session is invalidated.
+    /// - Parameter shouldFinishTasks: Determines whether all outstanding tasks should finish before invalidating the session or be immediately cancelled.
+    func invalidateSession(shouldFinishTasks: Bool)
+}

--- a/Sources/Networking/Core/Upload/UploadTask+State.swift
+++ b/Sources/Networking/Core/Upload/UploadTask+State.swift
@@ -1,0 +1,39 @@
+//
+//  UploadTask+State.swift
+//  
+//
+//  Created by Tony Ngo on 12.06.2023.
+//
+
+import Foundation
+
+extension UploadTask {
+    /// The upload task's state.
+    public struct State {
+        /// Number of bytes sent.
+        public let sentBytes: Int64
+
+        /// Number of bytes expected to send.
+        public let totalBytes: Int64
+
+        /// An error produced by the task.
+        public var error: Error?
+
+        /// A response produced by the task.
+        public var response: Response?
+
+        /// The internal state of the `URLSessionTask`.
+        let taskState: URLSessionTask.State
+    }
+}
+
+extension UploadTask.State {
+    /// Initializes the state from a `URLSessionTask`
+    init(task: URLSessionTask) {
+        sentBytes = task.countOfBytesSent
+        totalBytes = task.countOfBytesExpectedToSend
+        taskState = task.state
+        error = task.error
+    }
+}
+

--- a/Sources/Networking/Core/Upload/UploadTask+State.swift
+++ b/Sources/Networking/Core/Upload/UploadTask+State.swift
@@ -67,4 +67,3 @@ extension UploadTask.State {
         error = task.error
     }
 }
-

--- a/Sources/Networking/Core/Upload/UploadTask+State.swift
+++ b/Sources/Networking/Core/Upload/UploadTask+State.swift
@@ -27,6 +27,37 @@ extension UploadTask {
     }
 }
 
+public extension UploadTask.State {
+    /// The amount of data sent indicated by values from 0 to 1.
+    var fractionCompleted: Double {
+        totalBytes > 0 ? Double(sentBytes) / Double(totalBytes) : 0
+    }
+
+    var cancelled: Bool {
+        (error as? URLError)?.code == .cancelled
+    }
+
+    var timedOut: Bool {
+        (error as? URLError)?.code == .timedOut
+    }
+
+    var isRunning: Bool {
+        taskState == .running
+    }
+
+    var isSuspended: Bool {
+        taskState == .suspended
+    }
+
+    var isCanceling: Bool {
+        taskState == .canceling
+    }
+
+    var isCompleted: Bool {
+        taskState == .completed
+    }
+}
+
 extension UploadTask.State {
     /// Initializes the state from a `URLSessionTask`
     init(task: URLSessionTask) {

--- a/Sources/Networking/Core/Upload/UploadTask.swift
+++ b/Sources/Networking/Core/Upload/UploadTask.swift
@@ -10,6 +10,8 @@ import Foundation
 
 /// Represents and manages an upload task and provides its state.
 public struct UploadTask {
+    public typealias ID = String
+
     /// The session task this object represents.
     let task: URLSessionUploadTask
 
@@ -18,4 +20,13 @@ public struct UploadTask {
 
     /// Use this publisher to emit a new state of the task.
     let statePublisher: CurrentValueSubject<State, Never>
+}
+
+extension UploadTask: Identifiable {
+    /// An unique task identifier.
+    ///
+    /// The identifier value is equal to the internal request's identifier that this task is associated with.
+    public var id: ID {
+        endpointRequest.id
+    }
 }

--- a/Sources/Networking/Core/Upload/UploadTask.swift
+++ b/Sources/Networking/Core/Upload/UploadTask.swift
@@ -22,6 +22,19 @@ public struct UploadTask {
     let statePublisher: CurrentValueSubject<State, Never>
 }
 
+extension UploadTask {
+    /// The identifier of the underlying `URLSessionUploadTask`.
+    var taskIdentifier: Int {
+        task.taskIdentifier
+    }
+
+    /// An asynchronous sequence of the upload task' state.
+    var stateStream: AsyncPublisher<AnyPublisher<UploadTask.State, Never>> {
+        statePublisher.eraseToAnyPublisher().values
+    }
+}
+
+// MARK: - Identifiable
 extension UploadTask: Identifiable {
     /// An unique task identifier.
     ///

--- a/Sources/Networking/Core/Upload/UploadTask.swift
+++ b/Sources/Networking/Core/Upload/UploadTask.swift
@@ -22,6 +22,35 @@ public struct UploadTask {
     let statePublisher: CurrentValueSubject<State, Never>
 }
 
+public extension UploadTask {
+    /// Resumes the task.
+    /// Has no effect if the task is not in the suspended state.
+    func resume() {
+        if task.state == .suspended {
+            task.resume()
+            statePublisher.send(State(task: task))
+        }
+    }
+
+    /// Pauses the task.
+    ///
+    /// Call `resume()` to resume the upload.
+    /// - Note: While paused (suspended state), the task is still subject to timeouts.
+    func pause() {
+        task.suspend()
+        statePublisher.send(State(task: task))
+    }
+
+    /// Cancels the task.
+    ///
+    /// Calling this method will produce a `NSURLErrorCancelled` error
+    /// and set the task to the `URLSessionTask.State.cancelled` state.
+    func cancel() {
+        task.cancel()
+        statePublisher.send(State(task: task))
+    }
+}
+
 extension UploadTask {
     /// The identifier of the underlying `URLSessionUploadTask`.
     var taskIdentifier: Int {

--- a/Sources/Networking/Core/Upload/UploadTask.swift
+++ b/Sources/Networking/Core/Upload/UploadTask.swift
@@ -1,0 +1,21 @@
+//
+//  UploadTask.swift
+//  
+//
+//  Created by Tony Ngo on 12.06.2023.
+//
+
+import Combine
+import Foundation
+
+/// Represents and manages an upload task and provides its state.
+public struct UploadTask {
+    /// The session task this object represents.
+    let task: URLSessionUploadTask
+
+    /// The request associated with this task.
+    let endpointRequest: EndpointRequest
+
+    /// Use this publisher to emit a new state of the task.
+    let statePublisher: CurrentValueSubject<State, Never>
+}

--- a/Sources/Networking/Core/Upload/Uploadable.swift
+++ b/Sources/Networking/Core/Upload/Uploadable.swift
@@ -1,0 +1,14 @@
+//
+//  Uploadable.swift
+//  
+//
+//  Created by Tony Ngo on 13.06.2023.
+//
+
+import Foundation
+
+/// Represents a data type that can be uploaded.
+enum Uploadable {
+    case data(Data)
+    case file(URL)
+}


### PR DESCRIPTION
This pull request introduces an upload feature allowing clients to upload data and files (no stream or multipart file support yet). The implementation follows the existing download feature design with slight deviation whilst aiming to keep consistency and familiarity with the API. With that, the changes also include an example that showcases the usage of the API.

Please, do not consider this implementation as final but rather as the first draft.

## Video

https://github.com/strvcom/ios-networking/assets/20850404/01089bdd-7fc7-4157-ac6e-ecf24c7a88a8

## Implementation

### `UploadTask`

The central component is the `UploadTask` object that encapsulates the ongoing `URLSessionUploadTask` and provides the task's state updates. Each upload request creates an upload task instance that is internally stored until the request is completed. In case of a failed request, the UploadTask serves as the representation of the failed request and is important in subsequent retry attempts.

### `UploadTask.State`

This object represents the progress of the upload request and is updated continuously by the internal publisher. It is then available to the client as an asynchronous sequence. Since the implementation creates the `URLSessionUploadTask` with completion handlers, the response is accessible only upon the task's completion. Consequently, the response or error is delivered within the upload task's state.

### `Retryable`

The `UploadTask` conforms to the `Retryable` protocol instead of the `UploadAPIManager` as is in the `DownloadAPIManager`. This emphasizes the intention that the task itself is retryable, rather than the manager. Despite potentially deviating from the original design of the protocol, this approach seems to work as well. Each upload task has its `retryCounter: Counter` that determines whether the task should be retried based on the `RetryConfiguration`.

## Additional Notes
- The sample does not include a complete router example intentionally. I've used [this service](https://www.filestack.com/) for testing purposes.