### PR TITLE
[fix] URL query keys percent encoding

### DIFF
--- a/Sources/Networking/Misc/URLQueryItem+PercentEncoding.swift
+++ b/Sources/Networking/Misc/URLQueryItem+PercentEncoding.swift
@@ -12,8 +12,8 @@ extension URLQueryItem {
     
     func percentEncoded() -> URLQueryItem {
         var newQueryItem = self
-        newQueryItem.value = value?
-            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        newQueryItem.name = name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? name
+        newQueryItem.value = value?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
         
         return newQueryItem
     }

--- a/Tests/NetworkingTests/URLParametersTests.swift
+++ b/Tests/NetworkingTests/URLParametersTests.swift
@@ -32,10 +32,12 @@ final class URLParametersTests: XCTestCase {
     }
     
     func testDefaultEncoding() async throws {
-        let nameString = "name]surname"
-        let namePercentEncodedString = "name%5Dsurname"
-        
-        let router = Router.urlParameters(["name": nameString])
+        let keyString = "name[first]"
+        let keyPercentEncodedString = "name%5Bfirst%5D"
+        let valueString = "name]surname"
+        let valuePercentEncodedString = "name%5Dsurname"
+
+        let router = Router.urlParameters([keyString: valueString])
         let request = try router.asRequest()
         
         guard let url = request.url else {
@@ -44,9 +46,10 @@ final class URLParametersTests: XCTestCase {
         }
         
         let queryItems = percentEncodedQueryItems(from: url)
+        
         XCTAssertEqual(
-            queryItems.first(where: { $0.name == "name" })?.value,
-            namePercentEncodedString
+            queryItems.first(where: { $0.name == keyPercentEncodedString })?.value,
+            valuePercentEncodedString
         )
     }
 


### PR DESCRIPTION
Add percent encoding also for keys in url queries. Otherwise adding some non allowed character to the url query key would crash the app 😬