### PR TITLE
fix: rule out watchos directive for mutlipeer connectivity processor

### DIFF
--- a/Sources/Networking/Modifiers/Processors/EndpointRequestStorageProcessor/EndpointRequestStorageProcessor.swift
+++ b/Sources/Networking/Modifiers/Processors/EndpointRequestStorageProcessor/EndpointRequestStorageProcessor.swift
@@ -5,13 +5,10 @@
 //  Created by Matej Molnár on 12.12.2022.
 //
 
-import Foundation
+#if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
 
-#if os(watchOS)
-    import os
-#else
-    import OSLog
-#endif
+import Foundation
+import OSLog
 
 // MARK: - Modifier storing endpoint requests
 
@@ -293,3 +290,5 @@ private extension JSONEncoder {
         return encoder
     }()
 }
+
+#endif

--- a/Sources/Networking/Modifiers/Processors/EndpointRequestStorageProcessor/MultipeerConnectivityManager.swift
+++ b/Sources/Networking/Modifiers/Processors/EndpointRequestStorageProcessor/MultipeerConnectivityManager.swift
@@ -5,12 +5,9 @@
 //  Created by Jaroslav Janda on 12.10.2021.
 //
 
-#if os(watchOS)
-    import os
-#else
-    import OSLog
-#endif
+#if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
 
+import OSLog
 import MultipeerConnectivity
 
 open class MultipeerConnectivityManager: NSObject {
@@ -119,3 +116,5 @@ extension MultipeerConnectivityManager: MCSessionDelegate {
     public func session(_ session: MCSession, didStartReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, with progress: Progress) {}
     public func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, at localURL: URL?, withError error: Error?) {}
 }
+
+#endif


### PR DESCRIPTION
Multi peer Connectivity is not supported on watchOS.

https://developer.apple.com/documentation/multipeerconnectivity