### PR TITLE
[fix] allow to override default json decoder on APIManager

### DIFF
--- a/Sources/Networking/Core/APIManager.swift
+++ b/Sources/Networking/Core/APIManager.swift
@@ -39,11 +39,19 @@ import Foundation
  ```
  */
 open class APIManager: APIManaging, Retryable {
+    // MARK: Public variables
+    /// Default JSONDecoder implementation
+    public var defaultDecoder: JSONDecoder {
+        JSONDecoder()
+    }
+    
+    // MARK: Private variables
     private let requestAdapters: [RequestAdapting]
     private let responseProcessors: [ResponseProcessing]
     private let errorProcessors: [ErrorProcessing]
     private let responseProvider: ResponseProviding
     private let sessionId: String
+
     internal var retryCounter = Counter()
     
     public init(

--- a/Sources/Networking/Core/APIManaging.swift
+++ b/Sources/Networking/Core/APIManaging.swift
@@ -39,11 +39,6 @@ public protocol APIManaging {
 // MARK: - Provide request with default json decoder, retry configuration
 
 public extension APIManaging {
-    /// Default JSONDecoder implementation.
-    var defaultDecoder: JSONDecoder {
-        JSONDecoder.default
-    }
-    
     /// Simplifies request using a default ``RetryConfiguration``.
     /// - Parameter endpoint: API endpoint requestable definition.
     /// - Returns: ``Response``.
@@ -87,12 +82,4 @@ public extension APIManaging {
         let response = try await request(endpoint, retryConfiguration: retryConfiguration)
         return try decoder.decode(DecodableResponse.self, from: response.data)
     }
-}
-
-
-// MARK: - JSONDecoder static extension
-
-private extension JSONDecoder {
-    /// A static `JSONDecoder` instance used by default implementation of `APIManaging`
-    static let `default` = JSONDecoder()
 }


### PR DESCRIPTION
The original solution had default json encoder defined on APIManaging protocol and APIManager had not exposed this public variable so there was not a easy way to override default json decoder in APIManager subclasses.

I removed the default implementation on the protocol to force any APIManaging implementation to expose this variable. 
At the same time I don't want change init method for APIManager - any child class can solve it with custom init or just override the public property