### PR TITLE
[fix] accessory type for default decoder on api manager

### DIFF
--- a/Sources/Networking/Core/APIManager.swift
+++ b/Sources/Networking/Core/APIManager.swift
@@ -41,7 +41,7 @@ import Foundation
 open class APIManager: APIManaging, Retryable {
     // MARK: Public variables
     /// Default JSONDecoder implementation
-    public var defaultDecoder: JSONDecoder {
+    open var defaultDecoder: JSONDecoder {
         JSONDecoder()
     }
     


### PR DESCRIPTION
Fix accessory type